### PR TITLE
Rename to "browser-agent-version-pinning"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Browser Agent Version Pinning (nr1-browser-agent-version-pinning)
+# Browser Agent Version Pinning
 
-[![Tests](https://github.com/chris-pilcher/nr1-browser-agent-version-pinning/actions/workflows/test.yml/badge.svg?branch=initial-setup)](https://github.com/chris-pilcher/nr1-browser-agent-version-pinning/actions/workflows/test.yml) 
-[![GitHub Release](https://img.shields.io/github/v/release/chris-pilcher/nr1-browser-agent-version-pinning)](https://github.com/chris-pilcher/nr1-browser-agent-version-pinning/releases)
-[![License](https://img.shields.io/github/license/chris-pilcher/nr1-browser-agent-version-pinning.svg)](https://github.com/chris-pilcher/nr1-browser-agent-version-pinning/blob/main/LICENSE)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=chris-pilcher_nr1-browser-agent-version-pinning&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=chris-pilcher_nr1-browser-agent-version-pinning)
+[![Tests](https://github.com/chris-pilcher/browser-agent-version-pinning/actions/workflows/test.yml/badge.svg?branch=initial-setup)](https://github.com/chris-pilcher/browser-agent-version-pinning/actions/workflows/test.yml) 
+[![GitHub Release](https://img.shields.io/github/v/release/chris-pilcher/browser-agent-version-pinning)](https://github.com/chris-pilcher/browser-agent-version-pinning/releases)
+[![License](https://img.shields.io/github/license/chris-pilcher/browser-agent-version-pinning.svg)](https://github.com/chris-pilcher/browser-agent-version-pinning/blob/main/LICENSE)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=chris-pilcher_browser-agent-version-pinning&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=chris-pilcher_browser-agent-version-pinning)
 
 > Pin your browser agent version directly from the New Relic UI.
 
@@ -53,11 +53,11 @@ npm start
 
 Publishing is done via GitHub Actions. The following steps are required:
 
-- Create a new release in [GitHub](https://github.com/chris-pilcher/nr1-browser-agent-version-pinning/releases)
+- Create a new release in [GitHub](https://github.com/chris-pilcher/browser-agent-version-pinning/releases)
   - **Tag**: Tag version should be in the format `v1.2.3`
   - **Title**: Release title should be `X.Y.Z (Month Day, Year)`. E.g. `1.2.3 (June 1, 2021)`
   - **Description**: Release description should be a summary of changes.
-- Publish the release will trigger the [publish workflow](https://github.com/chris-pilcher/nr1-browser-agent-version-pinning/actions/workflows/publish.yml) in GitHub Actions
+- Publish the release will trigger the [publish workflow](https://github.com/chris-pilcher/browser-agent-version-pinning/actions/workflows/publish.yml) in GitHub Actions
   - Publish will set the NPM version based on the GitHub release tag from the previous step
   - Publish the Nerdpack to New Relic One
 - *Note: You must be a collaborator on the repository to publish*

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,4 @@
-sonar.projectKey=chris-pilcher_nr1-browser-agent-version-pinning
+sonar.projectKey=chris-pilcher_browser-agent-version-pinning
 sonar.organization=chris-pilcher
 sonar.javascript.lcov.reportPaths=./src/coverage/lcov.info
 sonar.coverage.exclusions=**/catalog/**,**/components/**,**/__tests__/**,**/__mocks__/**,**/scripts/**

--- a/src/catalog/config.json
+++ b/src/catalog/config.json
@@ -3,11 +3,11 @@
   "details": "Browser Agent Version Pinning lets you pin browser agents to specific versions. This ensures you can safely test future agent versions in non-production environments before applying them to production.",
   "categoryTerms": ["browser agent"],
   "keywords": ["browser", "pin", "pinning"],
-  "repository": "https://github.com/chris-pilcher/nr1-browser-agent-version-pinning",
+  "repository": "https://github.com/chris-pilcher/browser-agent-version-pinning",
   "whatsNew": "- Initial release",
   "support": {
     "issues": {
-      "url": "https://github.com/chris-pilcher/nr1-browser-agent-version-pinning/issues"
+      "url": "https://github.com/chris-pilcher/browser-agent-version-pinning/issues"
     }
   }
 }

--- a/src/nerdlets/browser-agent-version-pinning/constants/urls.js
+++ b/src/nerdlets/browser-agent-version-pinning/constants/urls.js
@@ -1,6 +1,6 @@
 export const URLS = {
   EOL: {
-    DATA: "https://chris-pilcher.github.io/nr1-browser-agent-version-pinning/browser-agent-eol-policy.json",
+    DATA: "https://chris-pilcher.github.io/browser-agent-version-pinning/browser-agent-eol-policy.json",
     DOCS: "https://docs.newrelic.com/docs/browser/browser-monitoring/getting-started/browser-agent-eol-policy/",
   },
   GITHUB: {

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "nr1-browser-agent-version-pinning",
+  "name": "browser-agent-version-pinning",
   "version": "1.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "nr1-browser-agent-version-pinning",
+      "name": "browser-agent-version-pinning",
       "dependencies": {
         "@tanstack/react-query": "^4.36.1",
         "prop-types": "15.8.1",

--- a/src/package.json
+++ b/src/package.json
@@ -12,7 +12,7 @@
     "@testing-library/react": "^16.1.0",
     "jest": "30.0.0-alpha.6",
     "jest-environment-jsdom": "30.0.0-alpha.6",
-    "prettier": "3.4.2"cd srn
+    "prettier": "3.4.2"
   },
   "nr1": {
     "uuid": "f56d4d88-7368-4b19-a5c6-3e465c017558"

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "name": "nr1-browser-agent-version-pinning",
+  "name": "browser-agent-version-pinning",
   "scripts": {
     "start": "nr1 nerdpack:serve",
     "test": "jest --coverage",
@@ -12,7 +12,7 @@
     "@testing-library/react": "^16.1.0",
     "jest": "30.0.0-alpha.6",
     "jest-environment-jsdom": "30.0.0-alpha.6",
-    "prettier": "3.4.2"
+    "prettier": "3.4.2"cd srn
   },
   "nr1": {
     "uuid": "f56d4d88-7368-4b19-a5c6-3e465c017558"


### PR DESCRIPTION
This pull request includes several changes aimed at renaming the project from `nr1-browser-agent-version-pinning` to `browser-agent-version-pinning`. The most important changes include updates to the `README.md`, configuration files, and package files to reflect the new project name.

Changes to documentation and references:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R6): Updated project name and associated URLs to reflect the new name `browser-agent-version-pinning`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R6) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L56-R60)

Updates to configuration files:

* [`sonar-project.properties`](diffhunk://#diff-43ed9d31bea2a6d518d69836bcd1a8e6bd81bf4df96c4745792c220ca5aa549cL1-R1): Changed the `sonar.projectKey` to match the new project name.
* [`src/catalog/config.json`](diffhunk://#diff-4ff012e6be94133d664e0642f507d73e822607387e6cc097036b2b1458e50aa6L6-R10): Updated repository and issue URLs to reflect the new project name.
* [`src/nerdlets/browser-agent-version-pinning/constants/urls.js`](diffhunk://#diff-d75187ac5c0a5007c551d2b45ac4ad318448bf49c12e1b7c1f3ffc1363235940L3-R3): Updated the URL for the browser agent EOL policy data to reflect the new project name.

Changes to package files:

* [`src/package-lock.json`](diffhunk://#diff-998cefe66c8f4a3c44a608be658fb845884ddbff34d948ca6c751f57186054b7L2-R8): Updated the project name in the package lock file to `browser-agent-version-pinning`.
* [`src/package.json`](diffhunk://#diff-cc5a2f170768969f124108ad3be7fdbcbed774c11774d99a87a3a78fef4ab97bL3-R3): Updated the project name in the package file to `browser-agent-version-pinning`.